### PR TITLE
refactor(client): make `sendRequest` and `buildRequest` be public

### DIFF
--- a/Sources/HttpX/Client/AsyncClient.swift
+++ b/Sources/HttpX/Client/AsyncClient.swift
@@ -160,11 +160,20 @@ public class AsyncClient: BaseClient {
         )
     }
 
-    // MARK: Internal
-
-    internal var delegate: AsyncStreamDelegate? // swiftlint:disable:this weak_delegate
-
-    internal func sendRequest(
+    /// Sends a network request, optionally streaming the response and handling authentication and redirects.
+    ///
+    /// - Parameters:
+    ///   - request: The `URLRequest` to be sent.
+    ///   - stream: A tuple indicating whether the response should be streamed and the chunk size for streaming.
+    ///             Defaults to `(false, nil)`, meaning no streaming.
+    ///   - auth: The authentication strategy to use. If `nil`, the client's default authentication will be used.
+    ///   - followRedirects: A Boolean value indicating whether the client should follow HTTP redirects.
+    ///                      If `nil`, the client's default setting will be used.
+    ///
+    /// - Returns: A `Response` object containing the response data.
+    ///
+    /// - Throws: An error if the request fails.
+    public func sendRequest(
         request: URLRequest,
         stream: (Bool, Int?) = (false, nil),
         auth: AuthType? = nil,
@@ -181,6 +190,10 @@ public class AsyncClient: BaseClient {
             history: []
         )
     }
+
+    // MARK: Internal
+
+    internal var delegate: AsyncStreamDelegate? // swiftlint:disable:this weak_delegate
 
     internal func sendHandlingAuth(
         request: URLRequest,

--- a/Sources/HttpX/Client/SyncClient.swift
+++ b/Sources/HttpX/Client/SyncClient.swift
@@ -161,11 +161,24 @@ public class SyncClient: BaseClient {
         )
     }
 
-    // MARK: Internal
-
-    internal var delegate: SyncStreamDelegate? // swiftlint:disable:this weak_delegate
-
-    internal func sendRequest(
+    /// Sends a network request with the given parameters, handling authentication and redirects as specified.
+    ///
+    /// This method sends a network request based on the provided `URLRequest` object. It supports streaming
+    /// of the response if required. Authentication and redirect following can be customized via the method parameters.
+    ///
+    /// - Parameters:
+    ///   - request: The `URLRequest` to be sent.
+    ///   - stream: A tuple indicating whether the response should be streamed (`true`)
+    ///             and the chunk size for streaming. The default is `(false, nil)`, indicating no streaming.
+    ///   - auth: An optional `AuthType` to be used for the request. If `nil`,
+    ///             the client's default authentication will be used.
+    ///   - followRedirects: An optional Boolean indicating whether redirects should be followed. If `nil`, the client's
+    ///                      default setting will be used.
+    ///
+    /// - Returns: A `Response` object containing the response data.
+    ///
+    /// - Throws: An error if the request fails, including network errors or authentication failures.
+    public func sendRequest(
         request: URLRequest,
         stream: (Bool, Int?) = (false, nil),
         auth: AuthType? = nil,
@@ -182,6 +195,10 @@ public class SyncClient: BaseClient {
             history: []
         )
     }
+
+    // MARK: Internal
+
+    internal var delegate: SyncStreamDelegate? // swiftlint:disable:this weak_delegate
 
     internal func sendHandlingAuth(
         request: URLRequest,


### PR DESCRIPTION
## Description

refactor(client): make `sendRequest` and `buildRequest` be public

## Motivation and Context

The downstream software I am developing requires these methods.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/rockmagma02/HttpX/blob/main/CODE_OF_CONDUCT.md) guide. (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [x] I have updated the documentation accordingly.
- [x] I have checked my code via `pre-commit run --all-files` (**required**)
- [x] I have ensured `swift test` pass. (**required**)
- [x] I have add all license via `make addlicense` (**required**)
